### PR TITLE
Update love versions through 11.5

### DIFF
--- a/loverocks/love-versions.lua
+++ b/loverocks/love-versions.lua
@@ -61,6 +61,34 @@ local versions = {
 		enet       = "1.2-1",
 		utf8       = "0.1.0-1"
 	},
+	["11.2"] = {
+		lua        = "5.1-1",
+		love       = "11.1-1",
+		luasocket  = "2.0.2-5",
+		enet       = "1.2-1",
+		utf8       = "0.1.0-1"
+	},
+	["11.3"] = {
+		lua        = "5.1-1",
+		love       = "11.1-1",
+		luasocket  = "2.0.2-5",
+		enet       = "1.2-1",
+		utf8       = "0.1.0-1"
+	},
+	["11.4"] = {
+		lua        = "5.1-1",
+		love       = "11.1-1",
+		luasocket  = "2.0.2-5",
+		enet       = "1.2-1",
+		utf8       = "0.1.0-1"
+	},
+	["11.5"] = {
+		lua        = "5.1-1",
+		love       = "11.1-1",
+		luasocket  = "2.0.2-5",
+		enet       = "1.2-1",
+		utf8       = "0.1.0-1"
+	},
 	-- HEY DUMMY, SEE THAT KEY NAMED LOVE?
 	-- YEAH THAT SHOULD BE THE SAME AS THE VERSION NUMBER
 }


### PR DESCRIPTION
An attempt to close #23 by adding love versions 11.2-11.5.

I'm not sure how to validate any of the versions listed - open to suggestions. But the changelogs for Love don't suggest any major updates in the build here.

I haven't run the tests - yet. I'm still kinda struggling to figure out how to set up environments in a sensible way. But I don't think any tests depend on the structure of this object, so felt OK pushing the PR.

See also https://github.com/Alloyed/loadconf/pull/6, which updates the stable version of love to 11.5.